### PR TITLE
Support for animated water planes

### DIFF
--- a/scripts/extensions/BoatExtension.lua
+++ b/scripts/extensions/BoatExtension.lua
@@ -2,8 +2,8 @@
     - inj_Boat_onBoatWaterPlaneRaycastCallback
 
       Override raycast callback in order to allow lifting boats out of the water if distance to waterplane is too great.
-      It raycasts downwards at vehicle root node position with y offset + 25.0 looking for closest waterplane.
-      Raycast distance is 50.0.
+      It raycasts downwards at vehicle root node position with y offset + 25.0 looking for closest waterplane
+      Raycast distance is 50.0
 
       Also handles animated water planes (e.g. lock/dam systems): when the water plane node moves but
       keeps the same node ID, the original code skips joint recreation. We detect the height change and
@@ -13,7 +13,7 @@
 
     - inj_Boat_onUpdate
 
-      Override waterEffectsMinSpeed in order to prevent water effects (if applicable) when the boat is out of the water.
+      Override waterEffectsMinSpeed in order to prevent water effects (if applicable) when the boat is out of the water
 
 
     - inj_Boat_onPreLoad
@@ -21,7 +21,7 @@
       Make sure that Boats work on other maps, prevent specialization setting custom position compression parameters.
 
 
-    - inj_Mission00_update
+      - post_Mission00_update
 
       Handles the case where a stationary, unoccupied boat needs to follow an animated water plane.
       When a boat is sleeping (stationary and unoccupied) its physics body is inactive, so onUpdateTick
@@ -74,7 +74,7 @@ local function inj_Boat_onBoatWaterPlaneRaycastCallback(self, superFunc, nodeId,
 end
 
 ---@param self Boat
-local function inj_Boat_onUpdate(self, superFunc, dt, ...)
+local function inj_Boat_onUpdate(self, superFunc, ...)
     ---@type Boat_spec
     local spec = self[Boat.SPEC_TABLE_NAME]
     local previousWaterEffectsMinSpeed = spec.waterEffectsMinSpeed
@@ -83,7 +83,7 @@ local function inj_Boat_onUpdate(self, superFunc, dt, ...)
         spec.waterEffectsMinSpeed = 1000
     end
 
-    superFunc(self, dt, ...)
+    superFunc(self, ...)
 
     spec.waterEffectsMinSpeed = previousWaterEffectsMinSpeed
 end
@@ -91,9 +91,8 @@ end
 ---@param self Boat
 ---@param superFunc function
 local function inj_Boat_onPreLoad(self, superFunc)
-    if g_mpLoadingScreen.missionInfo.mapId == 'pdlc_highlandsFishingPack.HighlandsFishingMap' then
-        superFunc(self)
-    end
+    -- void, skip calling superFunc to avoid setting custom vehicle
+    -- position compression parameters regardless of map.
 end
 
 ---@param self any
@@ -111,10 +110,17 @@ local function inj_Boat_onLoadFinished(self, superFunc)
 end
 
 local function inj_Boat_setBoatWaterPlaneId(self, superFunc, node)
-    superFunc(self, node)
-
     ---@type Boat_spec
     local spec = self[Boat.SPEC_TABLE_NAME]
+
+    if node ~= nil and spec.waterPlaneId ~= node then
+        if spec.jointIndex ~= nil then
+            removeJoint(spec.jointIndex)
+            spec.jointIndex = nil
+        end
+    end
+
+    superFunc(self, node)
 
     if spec.waterPlaneId ~= nil then
         if spec.waterSamples ~= nil and not spec.waterSamplesArePlaying then
@@ -148,60 +154,56 @@ g_soundManager:registerModifierType("BOAT_MOTOR_RPM", Boat.getMotorRpmReal)
 -- [0 .. 1] acceleration (absolute, in either direction)
 g_soundManager:registerModifierType("BOAT_ACCELERATION", Boat.getMotorRpmPercentage)
 
--- Per-vehicle state for the animated water plane tracker below.
-local _boatLastWaterY = {}  -- water plane node Y from the previous frame
-local _boatKeepAwake = {}   -- true while sleep thresholds are overridden for this vehicle
-
 ---@param self Mission00
 ---@param dt number
-local function inj_Mission00_update(self, dt)
+local function post_Mission00_update(self, dt)
     if g_server == nil then
         return
     end
 
-    local vs = g_currentMission and g_currentMission.vehicleSystem
-    local vehicles = vs and vs.vehicles
-    if vehicles == nil then
-        return
-    end
+    for _, vehicle in ipairs(self.vehicleSystem.vehicles) do
+        ---@cast vehicle Boat
+        if vehicle.isDeleted or (vehicle.isDeleting or not vehicle.isAddedToPhysics) then
+            continue
+        end
 
-    for _, vehicle in ipairs(vehicles) do
+        ---@type Boat_spec
         local spec = vehicle[Boat.SPEC_TABLE_NAME]
 
-        if spec ~= nil and spec.waterPlaneId ~= nil then
-            local _, nodeY, _ = getWorldTranslation(spec.waterPlaneId)
-            local lastY = _boatLastWaterY[vehicle]
-            _boatLastWaterY[vehicle] = nodeY
+        if spec ~= nil then
+            if spec.waterPlaneId ~= nil then
+                local _, nodeY, _ = getWorldTranslation(spec.waterPlaneId)
+                local lastY = spec.lastWaterPlaneHeight
+                spec.lastWaterPlaneHeight = nodeY
 
-            if lastY ~= nil then
-                local waterDelta = nodeY - lastY
+                if lastY ~= nil then
+                    local waterDelta = nodeY - lastY
 
-                if math.abs(waterDelta) > 0.005 then
-                    -- Water is moving: disable physics sleeping so the body stays awake,
-                    -- then keep the vehicle in the update loop so raycasts keep firing.
-                    -- The existing joint spring moves the boat smoothly to the new height.
-                    if not _boatKeepAwake[vehicle] then
-                        setSleepingThresholds(vehicle.rootNode, 0, 0)
-                        _boatKeepAwake[vehicle] = true
+                    if math.abs(waterDelta) > 0.005 then
+                        -- Water is moving: disable physics sleeping so the body stays awake,
+                        -- then keep the vehicle in the update loop so raycasts keep firing.
+                        -- The existing joint spring moves the boat smoothly to the new height.
+                        if not spec.keepAwake then
+                            setSleepingThresholds(vehicle.rootNode, 0, 0)
+                            spec.keepAwake = true
+                        end
+                        vehicle:raiseActive()
+                    elseif spec.keepAwake then
+                        -- Water has settled: restore the thresholds set in Boat.addToPhysics.
+                        setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
+                        spec.keepAwake = false
                     end
-                    vehicle:raiseActive()
-
-                elseif _boatKeepAwake[vehicle] then
-                    -- Water has settled: restore the thresholds set in Boat.addToPhysics.
-                    setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
-                    _boatKeepAwake[vehicle] = false
                 end
-            end
+            else
+                spec.lastWaterPlaneHeight = nil
 
-        elseif spec ~= nil then
-            -- waterPlaneId is nil (boat left water or not yet initialised).
-            _boatLastWaterY[vehicle] = nil
-            if _boatKeepAwake[vehicle] then
-                setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
-                _boatKeepAwake[vehicle] = false
+                if spec.keepAwake then
+                    setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
+                    spec.keepAwake = false
+                end
             end
         end
     end
 end
 
-Mission00.update = Utils.appendedFunction(Mission00.update, inj_Mission00_update)
+Mission00.update = Utils.appendedFunction(Mission00.update, post_Mission00_update)

--- a/scripts/extensions/BoatExtension.lua
+++ b/scripts/extensions/BoatExtension.lua
@@ -2,18 +2,37 @@
     - inj_Boat_onBoatWaterPlaneRaycastCallback
 
       Override raycast callback in order to allow lifting boats out of the water if distance to waterplane is too great.
-      It raycasts downwards at vehicle root node position with y offset + 25.0 looking for closest waterplane
-      Raycast distance is 50.0
+      It raycasts downwards at vehicle root node position with y offset + 25.0 looking for closest waterplane.
+      Raycast distance is 50.0.
+
+      Also handles animated water planes (e.g. lock/dam systems): when the water plane node moves but
+      keeps the same node ID, the original code skips joint recreation. We detect the height change and
+      force the physics joint to be rebuilt at the new water surface level so the joint spring pulls the
+      boat to the new height. This covers boats that are active (player aboard or boat already moving).
 
 
     - inj_Boat_onUpdate
 
-      Override waterEffectsMinSpeed in order to prevent water effects (if applicable) when the boat is out of the water
+      Override waterEffectsMinSpeed in order to prevent water effects (if applicable) when the boat is out of the water.
 
 
     - inj_Boat_onPreLoad
 
       Make sure that Boats work on other maps, prevent specialization setting custom position compression parameters.
+
+
+    - inj_Mission00_update
+
+      Handles the case where a stationary, unoccupied boat needs to follow an animated water plane.
+      When a boat is sleeping (stationary and unoccupied) its physics body is inactive, so onUpdateTick
+      and its raycasts stop firing and the boat no longer tracks the water surface.
+
+      Each frame we read the water plane node's world Y directly and compare it to the previous frame.
+      When the water is moving we call setSleepingThresholds(0, 0) to disable physics sleeping on the
+      boat body (waking it if already asleep) and raiseActive() to keep it in the script update loop.
+      This lets the existing onUpdateTick raycasts and joint spring move the boat naturally and smoothly.
+      When the water settles we restore the normal sleep thresholds (0.3 / 0.35) so the boat can sleep
+      again. Server only — clients follow via normal vehicle position sync.
 ]]
 
 ---@param self Boat
@@ -31,11 +50,31 @@ local function inj_Boat_onBoatWaterPlaneRaycastCallback(self, superFunc, nodeId,
         return true
     end
 
-    return superFunc(self, nodeId, x, y, z, distance, nx, ny, nz, subShapeIndex, shapeId, isLast)
+    local prevHeight = spec.waterPlaneHeight
+
+    superFunc(self, nodeId, x, y, z, distance, nx, ny, nz, subShapeIndex, shapeId, isLast)
+
+    -- When the water plane node is animated (e.g. a lock/dam raising/lowering water),
+    -- the raycast hits the same nodeId at a new Y position. The original code only calls
+    -- setBoatWaterPlaneId when the node changes, so the physics joint is never updated.
+    -- Detect the height change here and force a joint rebuild at the new water surface.
+    -- The body is awake (raycasts only run for active vehicles) so just rebuilding the
+    -- joint is enough; the spring will pull the boat to the new height.
+    --
+    -- Remove the old joint directly rather than routing through setBoatWaterPlaneId(nil),
+    -- so waterPlaneId stays non-nil during the rebuild. updateBoatControl gates the motor
+    -- on waterPlaneId ~= nil, so going through nil would disable thrust every rebuild.
+    if spec.waterPlaneId ~= nil and math.abs(prevHeight - spec.waterPlaneHeight) > 0.1 then
+        if spec.jointIndex ~= nil then
+            removeJoint(spec.jointIndex)
+            spec.jointIndex = nil
+        end
+        self:setBoatWaterPlaneId(spec.waterPlaneId)
+    end
 end
 
 ---@param self Boat
-local function inj_Boat_onUpdate(self, superFunc, ...)
+local function inj_Boat_onUpdate(self, superFunc, dt, ...)
     ---@type Boat_spec
     local spec = self[Boat.SPEC_TABLE_NAME]
     local previousWaterEffectsMinSpeed = spec.waterEffectsMinSpeed
@@ -44,7 +83,7 @@ local function inj_Boat_onUpdate(self, superFunc, ...)
         spec.waterEffectsMinSpeed = 1000
     end
 
-    superFunc(self, ...)
+    superFunc(self, dt, ...)
 
     spec.waterEffectsMinSpeed = previousWaterEffectsMinSpeed
 end
@@ -108,3 +147,61 @@ g_soundManager:registerModifierType("BOAT_MOTOR_RPM", Boat.getMotorRpmReal)
 
 -- [0 .. 1] acceleration (absolute, in either direction)
 g_soundManager:registerModifierType("BOAT_ACCELERATION", Boat.getMotorRpmPercentage)
+
+-- Per-vehicle state for the animated water plane tracker below.
+local _boatLastWaterY = {}  -- water plane node Y from the previous frame
+local _boatKeepAwake = {}   -- true while sleep thresholds are overridden for this vehicle
+
+---@param self Mission00
+---@param dt number
+local function inj_Mission00_update(self, dt)
+    if g_server == nil then
+        return
+    end
+
+    local vs = g_currentMission and g_currentMission.vehicleSystem
+    local vehicles = vs and vs.vehicles
+    if vehicles == nil then
+        return
+    end
+
+    for _, vehicle in ipairs(vehicles) do
+        local spec = vehicle[Boat.SPEC_TABLE_NAME]
+
+        if spec ~= nil and spec.waterPlaneId ~= nil then
+            local _, nodeY, _ = getWorldTranslation(spec.waterPlaneId)
+            local lastY = _boatLastWaterY[vehicle]
+            _boatLastWaterY[vehicle] = nodeY
+
+            if lastY ~= nil then
+                local waterDelta = nodeY - lastY
+
+                if math.abs(waterDelta) > 0.005 then
+                    -- Water is moving: disable physics sleeping so the body stays awake,
+                    -- then keep the vehicle in the update loop so raycasts keep firing.
+                    -- The existing joint spring moves the boat smoothly to the new height.
+                    if not _boatKeepAwake[vehicle] then
+                        setSleepingThresholds(vehicle.rootNode, 0, 0)
+                        _boatKeepAwake[vehicle] = true
+                    end
+                    vehicle:raiseActive()
+
+                elseif _boatKeepAwake[vehicle] then
+                    -- Water has settled: restore the thresholds set in Boat.addToPhysics.
+                    setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
+                    _boatKeepAwake[vehicle] = false
+                end
+            end
+
+        elseif spec ~= nil then
+            -- waterPlaneId is nil (boat left water or not yet initialised).
+            _boatLastWaterY[vehicle] = nil
+            if _boatKeepAwake[vehicle] then
+                setSleepingThresholds(vehicle.rootNode, 0.3, 0.35)
+                _boatKeepAwake[vehicle] = false
+            end
+        end
+    end
+end
+
+Mission00.update = Utils.appendedFunction(Mission00.update, inj_Mission00_update)


### PR DESCRIPTION
This is the updated PR. I had put the BoatExtension.lua in the wrong place with my first PR so it was still loading original version.
Let me know if you have any further issues.

Maps with animated water planes (e.g. lock/dam systems where the water surface rises and falls) expose two gaps in the current boat tracking logic. This PR fixes both.

Problem 1 — Active boats don't follow animated water (same node ID, new Y)

onBoatWaterPlaneRaycastCallback only calls setBoatWaterPlaneId when nodeId changes. When a water plane is animated it keeps the same node ID at a new world Y position, so the physics joint target is never updated and the boat stays at the old height.

Fix: Capture spec.waterPlaneHeight before calling superFunc. If the height changed by more than 0.1 m after the call, force a joint rebuild by calling setBoatWaterPlaneId(nil) then setBoatWaterPlaneId(planeId).

Problem 2 — Sleeping/unoccupied boats don't follow animated water

When a boat is stationary and unoccupied, the physics body sleeps. onUpdateTick and its raycasts stop firing, so the existing joint spring has no chance to move the boat.

Fix: Add inj_Mission00_update (server-only, appended to Mission00.update). Each frame it reads the water plane node's world Y for every boat that has a waterPlaneId. When the water is moving (delta > 0.005 m/frame):

setSleepingThresholds(vehicle.rootNode, 0, 0) — disables physics sleeping, which also wakes an already-sleeping body in Giants Engine
vehicle:raiseActive() — keeps the vehicle in the script update loop so raycasts keep firing
The existing raycast + joint spring system then moves the boat naturally and smoothly — no position teleporting. When the water settles, sleep thresholds are restored to (0.3, 0.35) (the values set in Boat:addToPhysics) so the boat can sleep normally again.

Clients follow via normal vehicle position network sync; no client-side changes are needed. 

In order to animate a water object it must be set to a kinematic body instead of static.
I recommend keeping the object fairly rectangular and as small as possible as during testing when I was trying to animate the entire ocean/river system on a map, changing it to kinematic made it to where I was swimming even when I wasn't over the water object due to Giants engine limitations.